### PR TITLE
Fix IncrementMetric transformation for nested expressions

### DIFF
--- a/gluten-delta/src-delta-32/main/scala/org/apache/gluten/execution/DeltaFilterExecTransformer.scala
+++ b/gluten-delta/src-delta-32/main/scala/org/apache/gluten/execution/DeltaFilterExecTransformer.scala
@@ -49,17 +49,15 @@ case class DeltaFilterExecTransformer(condition: Expression, child: SparkPlan)
       input: RelNode,
       validation: Boolean): RelNode = {
     assert(condExpr != null)
-    val condExprNode = condExpr match {
-      case IncrementMetric(child, metric) =>
-        extraMetrics :+= (condExpr.prettyName, metric)
-        ExpressionConverter
-          .replaceWithExpressionTransformer(child, attributeSeq = originalInputAttributes)
-          .doTransform(context)
-      case _ =>
-        ExpressionConverter
-          .replaceWithExpressionTransformer(condExpr, attributeSeq = originalInputAttributes)
-          .doTransform(context)
+    val cleanedExpr = condExpr.transformUp {
+      case im @ IncrementMetric(child, metric) =>
+        extraMetrics :+= (im.prettyName, metric)
+        child
     }
+    val condExprNode =
+      ExpressionConverter
+        .replaceWithExpressionTransformer(cleanedExpr, attributeSeq = originalInputAttributes)
+        .doTransform(context)
 
     if (!validation) {
       RelBuilder.makeFilterRel(input, condExprNode, context, operatorId)

--- a/gluten-delta/src-delta-32/main/scala/org/apache/gluten/execution/DeltaProjectExecTransformer.scala
+++ b/gluten-delta/src-delta-32/main/scala/org/apache/gluten/execution/DeltaProjectExecTransformer.scala
@@ -85,8 +85,15 @@ case class DeltaProjectExecTransformer(projectList: Seq[NamedExpression], child:
             extraMetrics :+= (im.prettyName, metric)
             child
         }
-        Alias(child = newChild, name = alias.name)(alias.exprId)
-      case other => other
+        alias.copy(child = newChild)
+      case other =>
+        other
+          .transformUp {
+            case im @ IncrementMetric(child, metric) =>
+              extraMetrics :+= (im.prettyName, metric)
+              child
+          }
+          .asInstanceOf[NamedExpression]
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix delta project transformer to handle IncrementMetric in any expression
- fix delta filter transformer to strip nested IncrementMetric expressions

## Testing
- `mvn` and `spotless` are unavailable in the environment so no tests were run